### PR TITLE
fix: [TR-457] incomplete user information

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,7 +309,6 @@ GEM
       nokogiri (~> 1)
       rake
     mini_mime (1.1.5)
-    mini_portile2 (2.8.7)
     minitest (5.19.0)
     msgpack (1.7.2)
     multi_xml (0.6.0)
@@ -325,9 +324,6 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
-    nokogiri (1.15.4)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -588,7 +584,6 @@ GEM
     zeitwerk (2.6.11)
 
 PLATFORMS
-  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,6 +309,7 @@ GEM
       nokogiri (~> 1)
       rake
     mini_mime (1.1.5)
+    mini_portile2 (2.8.7)
     minitest (5.19.0)
     msgpack (1.7.2)
     multi_xml (0.6.0)
@@ -324,6 +325,9 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.15.4)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -584,6 +588,7 @@ GEM
     zeitwerk (2.6.11)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,3 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :email, :document_number
+  attributes :id, :email, :document_number, :first_name, :last_name
 end


### PR DESCRIPTION
## JIRA Card

https://widergy.atlassian.net/browse/TR-457

## Summary

La respuesta del servicio `current_user` ,que devuelve la informacion del usuario que actualmente esta logueado, estaba incompleta, ya que no devolvia los campos `first_name` y `last_name`. La clase que se modifico en este fix fue la de User Serializer, encargado de exponer los campos del user, agregando los campos que faltaban. No se modifico la documentacion de la API.

## Screenshots
**South Utility**
_Antes_
![image](https://github.com/user-attachments/assets/b86933ff-5b63-4685-913e-25f9f791f153)

_Despues_
![image](https://github.com/user-attachments/assets/9c595888-2c43-4812-86ae-1c09628c4aef)

**North Utility**
_Antes_
![image](https://github.com/user-attachments/assets/a4ccc857-1edd-4b5d-a3fa-39c16adc3bc5)

_Despues_
![image](https://github.com/user-attachments/assets/bfd0ec83-5441-48d4-9c9f-e222946e206a)

Screens de tests y linter corriendo exitosamente:
![image](https://github.com/user-attachments/assets/3fb9a303-5d8b-4f32-9617-6f6594430eb9)
![image](https://github.com/user-attachments/assets/507739f8-7190-4e26-8fa6-78ecc5012fce)



## Test Cases

Pegarle al servicio de usuarios para obtener el current user. 
Primero es necesario generar un token JWT para obtener una sesion. Es decir, hacer un POST al endpoint `/api/v1/users/sessions` con un usuario existente de modo de autenticarse. Luego, realizar un GET al endpoint `/api/v1/users/current`, conteniendo el token JWT que se obtuvo en el primer paso dentro del Authorization header. Esto deberia devolver la informacion del usuario logueado, con los campos correspondientes. 
