### PR TITLE
feat: [TR-464] note create

### DIFF
--- a/app/controllers/api/v1/notes_controller.rb
+++ b/app/controllers/api/v1/notes_controller.rb
@@ -3,12 +3,24 @@ module Api
     class NotesController < ApplicationController
       before_action :authenticate_user!
 
+      def create
+        note = current_user.notes.create(params.require(:note)
+                                                .permit(:title,
+                                                        :content,
+                                                        :note_type))
+        render_resource(note)
+      end
+
       def index
-        render json: notes_filtered, status: :ok, each_serializer: IndexNoteSerializer
+        render json: notes_filtered,
+               status: :ok,
+               each_serializer: IndexNoteSerializer
       end
 
       def show
-        render json: show_note, status: :ok, serializer: NoteSerializer
+        render json: show_note,
+               status: :ok,
+               serializer: NoteSerializer
       end
 
       private

--- a/app/controllers/api/v1/notes_controller.rb
+++ b/app/controllers/api/v1/notes_controller.rb
@@ -8,7 +8,8 @@ module Api
                                                 .permit(:title,
                                                         :content,
                                                         :note_type))
-        render_resource(note)
+
+        render_resource(note, { message: I18n.t('notes_create_success') })
       end
 
       def index

--- a/app/controllers/api/v1/notes_controller.rb
+++ b/app/controllers/api/v1/notes_controller.rb
@@ -3,17 +3,16 @@ module Api
     class NotesController < ApplicationController
       before_action :authenticate_user!
       rescue_from ActionController::ParameterMissing, with: :render_missing_parameter_error
+      rescue_from ActiveRecord::RecordInvalid, with: :note_create_validation_error
 
       def create
         return render_invalid_note_type if invalid_note_type?(create_note_parameters[:note_type])
-        return note_create_validation_error(new_note.errors) unless new_note.errors.empty?
-        render json: { message: I18n.t('success.messages.note.create_success') }, status: :created
+        create_note_and_render_success
       end
 
       def index
         return render_invalid_note_type if invalid_note_type?(params.require(:note_type))
         return render_invalid_order if invalid_order?
-
         render json: notes, status: :ok, each_serializer: BriefNoteSerializer
       end
 
@@ -23,14 +22,14 @@ module Api
 
       private
 
-      def new_note
-        Note.create(
-          params.require(:note)
-                .permit(:title,
-                        :content,
-                        :note_type)
-                .merge(user_id: current_user.id)
-        )
+      def create_note_and_render_success
+        create_note
+        render json: { message: I18n.t('success.messages.note.create_success') }, status: :created
+      end
+
+      def create_note
+        Note.create!(params.require(:note).permit(:title, :content, :note_type)
+                           .merge(user_id: current_user.id))
       end
 
       def create_note_parameters
@@ -75,9 +74,10 @@ module Api
         render json: { error: I18n.t('errors.messages.note.missing_param') }, status: :bad_request
       end
 
-      def note_create_validation_error(errors)
-        errors = { error: errors[:content].first } if errors[:content].present?
-        render json: errors, status: :unprocessable_entity
+      def note_create_validation_error
+        threshold = current_user.utility.short_threshold
+        error_message = I18n.t('errors.messages.note.invalid_content_length', threshold: threshold)
+        render json: { error: error_message }, status: :unprocessable_entity
       end
     end
   end

--- a/app/controllers/api/v1/notes_controller.rb
+++ b/app/controllers/api/v1/notes_controller.rb
@@ -4,12 +4,7 @@ module Api
       before_action :authenticate_user!
 
       def create
-        note = current_user.notes.create(params.require(:note)
-                                                .permit(:title,
-                                                        :content,
-                                                        :note_type))
-
-        render_resource(note, { message: I18n.t('notes_create_success') })
+        render_create_message(new_note)
       end
 
       def index
@@ -21,6 +16,21 @@ module Api
       end
 
       private
+
+      def new_note
+        current_user.notes.create(params.require(:note)
+                                                .permit(:title,
+                                                        :content,
+                                                        :note_type))
+      end
+
+      def render_create_message(resource)
+        resource.errors.empty? ? render_created : validation_error(resource)
+      end
+
+      def render_created
+        render json: { message: I18n.t('notes_create_success') }, status: :created
+      end
 
       def note
         notes.find(params.require(:id))

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,8 +37,8 @@ class ApplicationController < ActionController::Base
     }, status: :bad_request
   end
 
-  def render_resource(resource)
-    resource.errors.empty? ? resource_created(resource) : validation_error(resource)
+  def render_resource(resource, response_resource = resource)
+    resource.errors.empty? ? resource_created(response_resource) : validation_error(resource)
   end
 
   def resource_created(resource)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,8 +37,8 @@ class ApplicationController < ActionController::Base
     }, status: :bad_request
   end
 
-  def render_resource(resource, response_resource = resource)
-    resource.errors.empty? ? resource_created(response_resource) : validation_error(resource)
+  def render_resource(resource)
+    resource.errors.empty? ? resource_created(resource) : validation_error(resource)
   end
 
   def resource_created(resource)

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -35,6 +35,8 @@ class Note < ApplicationRecord
   def validate_content_word_count
     return unless note_type == 'review' && content_length != 'short'
 
-    errors.add(:content, I18n.t('errors.messages.note.invalid_content_length'))
+    errors.add(:content,
+               I18n.t('errors.messages.note.invalid_content_length',
+                      threshold: utility.short_threshold))
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,12 +31,15 @@
 
 en:
   hello: "Hello world"
-  content_length_error: "length must be short for Review type"
-  notes_create_success: "Note created successfully"
+  success:
+    messages:
+      note:
+        create_success: "Note created successfully"
   errors:
     messages:
       note:
-        invalid_content_length: "length must be short for Review type"
+        invalid_content_length: "Content length must be at most %{threshold} characters long for Review type"
         invalid_note_type: "Invalid Note type"
         invalid_order: "Invalid order"
+        missing_param: "Missing required parameter"
       incorrect_parameter: "Missing or unpermitted parameter"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,8 +33,6 @@ en:
   hello: "Hello world"
   content_length_error: "length must be short for Review type"
   notes_create_success: "Note created successfully"
-  invalid_note_type_error: "Invalid note type"
-  invalid_order_error: "Invalid order"
   errors:
     messages:
       invalid_note_type: "Invalid Note type"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,3 +32,4 @@
 en:
   hello: "Hello world"
   content_length_error: "length must be short for Review type"
+  notes_create_success: "Note created successfully"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -32,3 +32,4 @@
 es:
   hello: "Hola Mundo!"
   content_length_error: "debe ser corto para el tipo Reseña"
+  notes_create_success: "Nota creada con exito."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -31,12 +31,15 @@
 
 es:
   hello: "Hola Mundo!"
-  content_length_error: "debe ser corto para el tipo Reseña"
-  notes_create_success: "Nota creada con exito."
+  success:
+    messages:
+      note:
+        create_success: "Nota creada con exito"
   errors:
     messages:
       note:
-        invalid_content_length: "debe ser corto para el tipo Reseña"
+        invalid_content_length: "Una reseña no puede superar los %{threshold} caracteres"
         invalid_note_type: "Tipo de nota inválido"
         invalid_order: "Orden inválido"
+        missing_param: "Faltan parámetros requeridos"
       incorrect_parameter: "Parámetro faltante o no permitido"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -32,12 +32,7 @@
 es:
   hello: "Hola Mundo!"
   content_length_error: "debe ser corto para el tipo Reseña"
-<<<<<<< HEAD
   notes_create_success: "Nota creada con exito."
-  invalid_note_type_error: "Tipo de nota inválido"
-  invalid_order_error: "Orden inválido"
-=======
->>>>>>> TR-463-feat-note-controller-tests
   errors:
     messages:
       incorrect_parameter: "Parámetro faltante o no permitido"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
     resource :users do
       get :current
     end
-    resources :notes, only: %i[index show]
+    resources :notes, only: %i[index show create]
 
   end
 

--- a/spec/controllers/api/v1/notes_controller_spec.rb
+++ b/spec/controllers/api/v1/notes_controller_spec.rb
@@ -161,7 +161,7 @@ describe Api::V1::NotesController, type: :controller do
         before { post :create, params: { note: note_params } }
 
         it 'responds with the created note' do
-          expect(response_body['message']).to eq(I18n.t('notes_create_success'))
+          expect(response_body['message']).to eq(I18n.t('success.messages.note.create_success'))
         end
 
         it 'responds with 201 status' do

--- a/spec/controllers/api/v1/notes_controller_spec.rb
+++ b/spec/controllers/api/v1/notes_controller_spec.rb
@@ -47,7 +47,11 @@ describe Api::V1::NotesController, type: :controller do
 
         before { get :index, params: valid_required_params.except(missing_param) }
 
-        it_behaves_like 'missing parameter bad request'
+        it_behaves_like 'bad request'
+
+        it 'responds with the correct missing parameter error message' do
+          expect(response_body['error']).to eq(I18n.t('errors.messages.note.missing_param'))
+        end
       end
 
       context 'when fetching notes with an invalid note type' do
@@ -116,28 +120,60 @@ describe Api::V1::NotesController, type: :controller do
   describe 'POST #create' do
     context 'when there is a user logged in' do
       include_context 'with authenticated user'
+      let(:note_params) { attributes_for(:note) }
 
-      context 'when creating a note' do
-        let(:note_params) { attributes_for(:note) }
+      context 'when creating a valid note' do
+        let(:created_resource) { Note.where(note_params) }
 
         before { post :create, params: { note: note_params } }
 
-        it 'responds with the created note' do
-          expect(response_body['message']).to eq(I18n.t('success.messages.note.create_success'))
-        end
+        it_behaves_like 'successful create response'
 
-        it 'responds with 201 status' do
-          expect(response).to have_http_status(:created)
+        it 'responds the custom success message' do
+          expect(response_body['message']).to eq(I18n.t('success.messages.note.create_success'))
         end
       end
 
-      context 'when creating an invalid note' do
-        let(:note_params) { { title: nil } }
+      context 'when attempting to create a note with missing parameter' do
+        let(:missing_param) { note_params.keys.sample }
+
+        before { post :create, params: { note: note_params.except(missing_param) } }
+
+        it 'responds with the correct missing parameter error message' do
+          expect(response_body['error']).to eq(I18n.t('errors.messages.note.missing_param'))
+        end
+
+        it 'responds error status' do
+          expect(response).to have_http_status(:bad_request)
+        end
+      end
+
+      context 'when creating a note with an invalid note type' do
+        let(:note_params) { attributes_for(:note).merge(note_type: :invalid_type) }
 
         before { post :create, params: { note: note_params } }
 
-        it 'responds with 400 status' do
-          expect(response).to have_http_status(:bad_request)
+        it_behaves_like 'unprocessable entity response'
+
+        it 'responds with the correct invalid note type error message' do
+          expect(response_body['error']).to eq(I18n.t('errors.messages.note.invalid_note_type'))
+        end
+      end
+
+      context 'when creating a note with type review and invalid content length' do
+        let(:word_count) { Faker::Number.between(from: user.utility.short_threshold + 1) }
+        let(:review_params) do
+          note_params.merge(note_type: :review)
+                     .merge(content: Faker::Lorem.sentence(word_count: word_count))
+                     .merge(user_id: user.id)
+        end
+
+        before { post :create, params: { note: review_params } }
+
+        it_behaves_like 'unprocessable entity response'
+
+        it 'responds with the correct invalid content length error message' do
+          expect(response_body['error']).to eq(I18n.t('errors.messages.note.invalid_content_length', threshold: user.utility.short_threshold))
         end
       end
     end

--- a/spec/controllers/api/v1/notes_controller_spec.rb
+++ b/spec/controllers/api/v1/notes_controller_spec.rb
@@ -135,7 +135,7 @@ describe Api::V1::NotesController, type: :controller do
         before { post :create, params: { note: note_params } }
 
         it 'responds with the created note' do
-          expect(response_body['content']).to eq(note_params[:content])
+          expect(response_body['message']).to eq(I18n.t('notes_create_success'))
         end
 
         it 'responds with 201 status' do

--- a/spec/controllers/api/v1/notes_controller_spec.rb
+++ b/spec/controllers/api/v1/notes_controller_spec.rb
@@ -124,4 +124,42 @@ describe Api::V1::NotesController, type: :controller do
       end
     end
   end
+
+  describe 'POST #create' do
+    context 'when there is a user logged in' do
+      include_context 'with authenticated user'
+
+      context 'when creating a note' do
+        let(:note_params) { attributes_for(:note) }
+
+        before { post :create, params: { note: note_params } }
+
+        it 'responds with the created note' do
+          expect(response_body['content']).to eq(note_params[:content])
+        end
+
+        it 'responds with 201 status' do
+          expect(response).to have_http_status(:created)
+        end
+      end
+
+      context 'when creating an invalid note' do
+        let(:note_params) { { title: nil } }
+
+        before { post :create, params: { note: note_params } }
+
+        it 'responds with 400 status' do
+          expect(response).to have_http_status(:bad_request)
+        end
+      end
+    end
+
+    context 'when there is not a user logged in' do
+      context 'when creating a note' do
+        before { post :create, params: { note: attributes_for(:note) } }
+
+        it_behaves_like 'unauthorized'
+      end
+    end
+  end
 end

--- a/spec/controllers/api/v1/notes_controller_spec.rb
+++ b/spec/controllers/api/v1/notes_controller_spec.rb
@@ -139,13 +139,11 @@ describe Api::V1::NotesController, type: :controller do
 
         before { post :create, params: { note: note_params.except(missing_param) } }
 
-        it 'responds with the correct missing parameter error message' do
+        it 'responds with the correct custom missing parameter error message' do
           expect(response_body['error']).to eq(I18n.t('errors.messages.note.missing_param'))
         end
 
-        it 'responds error status' do
-          expect(response).to have_http_status(:bad_request)
-        end
+        it_behaves_like 'bad request'
       end
 
       context 'when creating a note with an invalid note type' do
@@ -163,9 +161,7 @@ describe Api::V1::NotesController, type: :controller do
       context 'when creating a note with type review and invalid content length' do
         let(:word_count) { Faker::Number.between(from: user.utility.short_threshold + 1) }
         let(:review_params) do
-          note_params.merge(note_type: :review)
-                     .merge(content: Faker::Lorem.sentence(word_count: word_count))
-                     .merge(user_id: user.id)
+          note_params.merge(note_type: :review, content: Faker::Lorem.sentence(word_count: word_count), user_id: user.id)
         end
 
         before { post :create, params: { note: review_params } }

--- a/spec/controllers/api/v1/notes_controller_spec.rb
+++ b/spec/controllers/api/v1/notes_controller_spec.rb
@@ -136,26 +136,20 @@ describe Api::V1::NotesController, type: :controller do
 
       context 'when attempting to create a note with missing parameter' do
         let(:missing_param) { note_params.keys.sample }
+        let(:message) { I18n.t('errors.messages.note.missing_param') }
 
         before { post :create, params: { note: note_params.except(missing_param) } }
 
-        it 'responds with the correct custom missing parameter error message' do
-          expect(response_body['error']).to eq(I18n.t('errors.messages.note.missing_param'))
-        end
-
-        it_behaves_like 'bad request'
+        it_behaves_like 'bad request with message'
       end
 
       context 'when creating a note with an invalid note type' do
         let(:note_params) { attributes_for(:note).merge(note_type: :invalid_type) }
+        let(:message) { I18n.t('errors.messages.note.invalid_note_type') }
 
         before { post :create, params: { note: note_params } }
 
-        it_behaves_like 'unprocessable entity response'
-
-        it 'responds with the correct invalid note type error message' do
-          expect(response_body['error']).to eq(I18n.t('errors.messages.note.invalid_note_type'))
-        end
+        it_behaves_like 'unprocessable entity with message'
       end
 
       context 'when creating a note with type review and invalid content length' do
@@ -163,14 +157,11 @@ describe Api::V1::NotesController, type: :controller do
         let(:review_params) do
           note_params.merge(note_type: :review, content: Faker::Lorem.sentence(word_count: word_count), user_id: user.id)
         end
+        let(:message) { I18n.t('errors.messages.note.invalid_content_length', threshold: user.utility.short_threshold) }
 
         before { post :create, params: { note: review_params } }
 
-        it_behaves_like 'unprocessable entity response'
-
-        it 'responds with the correct invalid content length error message' do
-          expect(response_body['error']).to eq(I18n.t('errors.messages.note.invalid_content_length', threshold: user.utility.short_threshold))
-        end
+        it_behaves_like 'unprocessable entity with message'
       end
     end
 

--- a/spec/support/shared_examples/bad_request.rb
+++ b/spec/support/shared_examples/bad_request.rb
@@ -1,9 +1,5 @@
-shared_examples 'missing parameter bad request' do
+shared_examples 'bad request' do
   it 'returns status code bad request' do
     expect(response).to have_http_status(:bad_request)
-  end
-
-  it 'returns an error message' do
-    expect(response_body['error']).to eq(I18n.t('errors.messages.incorrect_parameter'))
   end
 end

--- a/spec/support/shared_examples/bad_request_with_message.rb
+++ b/spec/support/shared_examples/bad_request_with_message.rb
@@ -4,7 +4,7 @@ shared_examples 'bad request with message' do
   end
 
   it 'returns the appropiate error message' do
-    expect(response_body['errors'].first['message'])
+    expect(response_body['error'])
       .to eq(message)
   end
 end

--- a/spec/support/shared_examples/successful_create_request.rb
+++ b/spec/support/shared_examples/successful_create_request.rb
@@ -1,0 +1,9 @@
+shared_examples 'successful create response' do
+  it 'creates the resource and persists it to the database' do
+    expect(created_resource).to be_present
+  end
+
+  it 'responds with 201 status' do
+    expect(response).to have_http_status(:created)
+  end
+end

--- a/spec/support/shared_examples/successful_create_request.rb
+++ b/spec/support/shared_examples/successful_create_request.rb
@@ -1,6 +1,5 @@
 shared_examples 'successful create response' do
-  it 'creates the resource and persists it to the database without duplicates' do
-    expect(created_resource).to be_present
+  it 'creates the resource' do
     expect(created_resource.count).to eq(1)
   end
 

--- a/spec/support/shared_examples/successful_create_request.rb
+++ b/spec/support/shared_examples/successful_create_request.rb
@@ -1,6 +1,7 @@
 shared_examples 'successful create response' do
-  it 'creates the resource and persists it to the database' do
+  it 'creates the resource and persists it to the database without duplicates' do
     expect(created_resource).to be_present
+    expect(created_resource.count).to eq(1)
   end
 
   it 'responds with 201 status' do

--- a/spec/support/shared_examples/unprocessable_entity_with_message.rb
+++ b/spec/support/shared_examples/unprocessable_entity_with_message.rb
@@ -4,7 +4,7 @@ shared_examples 'unprocessable entity with message' do
   end
 
   it 'returns the appropiate error message' do
-    expect(response_body['errors'].first['message'])
+    expect(response_body['error'])
       .to eq(message)
   end
 end


### PR DESCRIPTION
## JIRA Card

https://widergy.atlassian.net/browse/TR-464

## Summary

Se implemento la ruta create para el controlador de Notas, con sus respectivos tests. 
No se cambio la documentacion.

## Screenshots
Post de una nota:
![image](https://github.com/user-attachments/assets/83412520-6e6f-4bcd-b79a-667c0d8096c3)

Post de una nota con algun campo faltando:
![image](https://github.com/user-attachments/assets/6bab1f25-d969-42b5-829a-82ee55e6cafe)

Post de una nota sin session
![image](https://github.com/user-attachments/assets/d7fd0ef6-ad88-4f3a-870c-3c0571e39e94)

Post de una nota no valida (contenido no es corto y es una resenia)
![image](https://github.com/user-attachments/assets/9861fd82-0f5b-4aa6-91b1-ca14fd716aee)



Tests y linter:
![image](https://github.com/user-attachments/assets/97cb3893-243b-4cbf-a285-fcf833d3aa08)

## Test Cases
Realizar una peticion POST a la siguiente ruta, siguiendo el formato valido de la [documentacion de apiary](https://widergytraininguguitoapi.docs.apiary.io/#reference/c.-notas/index-async/create) en el payload de la peticion. 
Hacer el POST a la siguiente ruta:
`{{base-api-url}}/api/v1/notes`

Luego, se puede probar sacarle el formato que pide la documentacion, y fijarse que retorne error valido. 
